### PR TITLE
fix: Update workflow to trigger on created and published events

### DIFF
--- a/.github/workflows/app-deploye.yml
+++ b/.github/workflows/app-deploye.yml
@@ -3,7 +3,7 @@ run-name: Pipeline for NerdBubble FE/BE release ${{ github.event.release.tag_nam
 
 on:
   release:
-    types: [published]
+    types: [created, published]
 
 env:
   APP_DIR: ./web-app


### PR DESCRIPTION
Adjusted the GitHub Actions workflow to support both `created` and `published` event types, enhancing deployment responsiveness for new and finalized releases.